### PR TITLE
Prevent ICSF suppliers from being shown on interflux.com

### DIFF
--- a/app/pods/contact/route.js
+++ b/app/pods/contact/route.js
@@ -21,6 +21,7 @@ export default class ContactRoute extends BaseRoute {
       countries: this.store.findAll('country'),
       markets: this.store.findAll('company-market'),
       companies: this.store.query('company', {
+        filter: { shownOnMainWebsite: 'true' },
         include: ['public_members', 'public_members.person'].join(',')
       }),
       events: this.store.query('event', {


### PR DESCRIPTION
This PR:

* Prevents ICSF suppliers from being shown on [interflux.com](https://interlfux.com/contact).

![CleanShot 2024-01-27 at 22 16 07](https://github.com/interflux-electronics/interflux-public-ember-frontend/assets/4415419/5449f128-50bf-448e-9f3d-f09ac247ce4d)
